### PR TITLE
Remove own repo reference in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,6 @@
     "name": "zicht/htmldev-bundle",
     "description": "Easy living styleguides with Symfony and Twig",
     "type": "symfony-bundle",
-    "repositories": [{
-        "type": "vcs",
-        "url": "git@github.com:zicht/htmldev-bundle.git"
-    }],
     "authors": [
         {
             "name": "Zicht Online",


### PR DESCRIPTION
It makes absolutely no sense to place the own Git repository as Composer repository in its own `composer.json`. The repositories section is being used to resolve the dependencies (`require` and `require-dev` sections). So Composer is now additionally going to fetch and read all `zicht/htmldev-bundle` versions (tags and branches) to resolve the dependencies of `zicht/htmldev-bundle`

![circle](https://media0.giphy.com/media/l41lPaVXzvGGMuAQ8/200w.gif?cid=5a38a5a25d3ad63a6655554b7717b684&rid=200w.gif)