### PR TITLE
Fix Htmldev Composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": "^7",
+        "knplabs/knp-menu-bundle": "^2.2",
         "rakit/validation": "^1.2",
         "symfony/framework-bundle": "*",
         "symfony/routing": "*",


### PR DESCRIPTION
Htmldev Bundle needs `knplabs/knp-menu-bundle`. Can't properly install the Htmldev Bundle on a vanilla Symfony 3.4 without this dependency.

https://github.com/zicht/htmldev-bundle/blob/13a481d84dabeb645b077e159a027085fd90c9e1/src/Zicht/Bundle/HtmldevBundle/Service/MenuBuilder.php#L5-L14