### PR TITLE
Fix controller FQCN

### DIFF
--- a/src/Zicht/Bundle/HtmldevBundle/Resources/config/services.xml
+++ b/src/Zicht/Bundle/HtmldevBundle/Resources/config/services.xml
@@ -18,7 +18,7 @@
             <argument type="service" id="templating" />
             <argument type="service" id="htmldev.yaml_data_loader" />
         </service>
-
+        <service id="Zicht\Bundle\HtmldevBundle\Controller\HtmldevController" alias="htmldev.htmldev_controller"/>
 
         <!-- Services -->
         <service id="htmldev.color_service" class="%htmldev.color_service%">


### PR DESCRIPTION
Tried to install the Htmldev Bundle on a vanilla Symfony 3.4 using autowiring. Controllers will be resolved based on FQCN.