### PR TITLE
Add menu uri voter

### DIFF
--- a/src/Zicht/Bundle/HtmldevBundle/Resources/config/services.xml
+++ b/src/Zicht/Bundle/HtmldevBundle/Resources/config/services.xml
@@ -80,5 +80,9 @@
             <argument type="service" id="request_stack" />
             <tag name="knp_menu.menu" alias="styleguide" />
         </service>
+        <service id="Zicht\Bundle\HtmldevBundle\Service\MenuUriVoter" class="Zicht\Bundle\HtmldevBundle\Service\MenuUriVoter">
+            <argument type="service" id="request_stack"/>
+            <tag name="knp_menu.voter" request="true"/>
+        </service>
     </services>
 </container>

--- a/src/Zicht/Bundle/HtmldevBundle/Service/MenuUriVoter.php
+++ b/src/Zicht/Bundle/HtmldevBundle/Service/MenuUriVoter.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright Zicht Online <https://zicht.nl>
+ */
+
+namespace Zicht\Bundle\HtmldevBundle\Service;
+
+use Knp\Menu\ItemInterface;
+use Knp\Menu\Matcher\Voter\VoterInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class MenuUriVoter implements VoterInterface
+{
+    /** @var RequestStack */
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * Checks whether an item is current.
+     *
+     * If the voter is not able to determine a result,
+     * it should return null to let other voters do the job.
+     *
+     * @param ItemInterface $item
+     * @return bool|null
+     */
+    public function matchItem(ItemInterface $item)
+    {
+        return $this->requestStack->getMasterRequest()->getPathInfo() === $item->getUri() ? true : null;
+    }
+}


### PR DESCRIPTION
For getting the current menu item, the Htmldev Bundle Styleguide relies on a service that is being added bij the Zicht Menu Bundle. Since the Zicht Menu Bundle is not a requirement, the Htmldev Bundle on a vanilla Symfony install does not have this service and cannot resolve the current menu item.

Since the Zicht Menu Bundle depends on Sonata, it would not be realistic to require the Zicht Menu Bundle within the Htmldev Bundle just to have this one single service available.

Therefor I added this service to the Htmldev Bundle.