### PR TITLE
Styleguide customization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Create living Styleguides with Symfony and Twig! ✨
       resource: "@ZichtHtmldevBundle/Resources/config/routing.yml"
    ```
 
-   ⚠️ if you combine this bundle with the [zicht/page-bundle](https://github.com/page-bundle), make sure this configuration is placed *above* any routing containing `/{locale}`.
+   ⚠️ if you combine this bundle with the [zicht/page-bundle](https://github.com/zicht/page-bundle), make sure this configuration is placed *above* any routing containing `/{locale}`.
 
-3. Add a app/config/bundles/ bundle configuration file to configure a Twig namespace and add project specific assets to
-the Styleguide (optionally you can configure the svg cache, see down below):
+3. Add an app/config/bundles/ bundle configuration file to configure a Twig namespace and add project specific assets to
+the Styleguide (optionally you can configure much more, see down below):
 
     ```yaml
     twig:
@@ -93,7 +93,27 @@ the following:
 
    ![](docs/initial-setup.jpg)
 
-6. By default SVG's will be cached on every other environment then development. This is due to performance reasons. It
+6. Optionally you can change the styleguide's title and its output.
+
+    * To change the Styleguide title, edit the config and add a `title: '...'` element:
+
+        ```yaml
+        zicht_htmldev:
+            styleguide:
+                title: 'Design System'
+        ```
+
+    * To change the Styleguide output, edit the config and add an `output: []` section:
+
+        ```yaml
+        zicht_htmldev:
+            styleguide:
+                output: ['example', 'twig', 'html'] # or ['example', 'html'] or ['example'] or ...
+        ```
+
+        Default (when not explicitly configured) is `output: ['example', 'twig']`
+
+7. By default SVG's will be cached on every other environment then development. This is due to performance reasons. It
 makes use of file caching for the rendered SVG files. In order to disable this on development you may want this to be
 array. To achieve this you could set the config param just like this:
 
@@ -188,8 +208,8 @@ The available options for rendering in the styleguide are:
 #### Pages
 
 The bundle renders default pages for all the components that are added to the `navigation.yml` and their own data
-Yaml files. The templates for the Styleguide reside within the HtmldevBundle own `Resources/views/styleguide/`
-directory and can be overridden within the project's `htmldev/pages/` directory. Both directory's structure looks
+Yaml files. The templates for the Styleguide reside within the HtmldevBundle's own `Resources/views/styleguide/`
+directory and can be overridden within the project's `htmldev/pages/` directory. Both directory's structures look
 like below. The HtmldevBundle has a base `component.html.twig` template for all components. You can override this
 template in your project's `htmldev/pages/` directory to do global changes. In your project's
 `htmldev/pages/` directory you can create a `components/` subdirectory and add custom templates for specific components
@@ -198,10 +218,14 @@ The design elements do have their own template within the HtmldevBundle, which a
 `component.html.twig` template (either the one in your project's `htmldev/pages/` directory or the one of the Htmldev
 bundle).
 
-Relative directory structure:
+You could also add a homepage/introduction page instead of going to the page of the first component in the list as
+homepage. You can do so by adding a template at `htmldev/pages/styleguide_intro.html.twig`. This will then be rendered
+as a homepage (at the `https://example.com/htmldev/` URL).
 
+Relative directory structure:
 ```
  ./
+  ├┈ (styleguide_intro.html.twig)
   ├─ component.html.twig
   ├┈ (components/)
   │  ├┈ (buttons.html.twig)

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "rakit/validation": "^1.2",
         "symfony/framework-bundle": "*",
         "symfony/routing": "*",
+        "twig/twig": "^2",
         "zicht/framework-extra-bundle": "^8",
         "zicht/twig-classes": "^1.0"
     },

--- a/src/Zicht/Bundle/HtmldevBundle/DependencyInjection/Configuration.php
+++ b/src/Zicht/Bundle/HtmldevBundle/DependencyInjection/Configuration.php
@@ -75,7 +75,7 @@ class Configuration implements ConfigurationInterface
      */
     private function buildStyleguideConfigTree($rootNode)
     {
-        if (isset($_SERVER['APPLICATION_ENV']) && 'production' === $_SERVER['APPLICATION_ENV']) {
+        if ('production' === getenv('APPLICATION_ENV')) {
             // Don't do any effort to validate the styleguide tree in production env.
             $rootNode->children()->variableNode('styleguide');
             return;
@@ -85,7 +85,15 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('styleguide')
                     ->fixXmlConfig('asset')
+                    ->fixXmlConfig('output')
                     ->children()
+                        ->scalarNode('title')->defaultValue('Styleguide')->end()
+                        ->arrayNode('outputs')
+                            ->info('Configure the outputs of the Styleguid: \'example\' will show the rendered component, \'twig\' will show the ui.component code to be used and \'html\' will show the rendered HTML output')
+                            ->defaultValue(['example', 'twig'])
+                            ->requiresAtLeastOneElement()
+                            ->enumPrototype()->values(['example', 'twig', 'html'])->end()
+                        ->end()
                         ->arrayNode('assets')
                             ->info(
                                 'These assets will be loaded additionally in the HTMLDEV Styleguide pages. Configure your website\'s stylesheet(s) and javascript(s) here.'

--- a/src/Zicht/Bundle/HtmldevBundle/DependencyInjection/ZichtHtmldevExtension.php
+++ b/src/Zicht/Bundle/HtmldevBundle/DependencyInjection/ZichtHtmldevExtension.php
@@ -35,8 +35,9 @@ class ZichtHtmldevExtension extends Extension
             $container->getDefinition('htmldev.svg_service')->replaceArgument(1, $cache);
         }
 
-        if (isset($config['styleguide']['assets']) && is_array($config['styleguide']['assets'])) {
-            $container->getDefinition('htmldev.htmldev_controller')->addMethodCall('setAssets', [$config['styleguide']['assets']]);
+        if (isset($config['styleguide']) && is_array($config['styleguide'])) {
+            $container->getDefinition('htmldev.htmldev_controller')
+                ->addMethodCall('setStyleguideConfig', [$config['styleguide']]);
         }
     }
 

--- a/src/Zicht/Bundle/HtmldevBundle/Resources/views/_base.html.twig
+++ b/src/Zicht/Bundle/HtmldevBundle/Resources/views/_base.html.twig
@@ -1,26 +1,24 @@
+{% set version = asset_version('/') -%}
 <!doctype html>
 <html class="s-no-javascript  not-loaded  {% block html_class '' %}" {% block html_attributes '' %}>
     <head>
         <meta charset="UTF-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <title>{%- if app.environment != 'production' %}{{ asset_version('/') }} - {% endif %}{% block head_title '' %}</title>
+        <title>{%- if app.environment != 'production' and version is not empty %}{{ version ~ ' - ' }}{% endif %}{% block head_title styleguide.title %}</title>
 
-        {% block head_copyright %}
+        {%~ block head_copyright %}
             <!--
             Copyright (c) Zicht Online {{ 'now'|date('Y') }} All rights reserved
-            Developed by: Zicht online
+            Developed by: Zicht Online
             Contact: info@zicht.nl
-            Version: {{ asset_version('/') }}
+            Version: {{ version ?: 'n.a.' }}
             -->
         {% endblock %}
 
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         {% block head -%}
-            {%- if assets is not defined or assets is not iterable -%}
-                {%- set assets = [] -%}
-            {%- endif -%}
-            {%- set assets = [{ type: 'stylesheet', path: 'bundles/zichthtmldev/css/styleguide.css' }] |merge(assets) -%}
+            {%- set assets = [{ type: 'stylesheet', path: 'bundles/zichthtmldev/css/styleguide.css' }] |merge(styleguide.assets) -%}
 
             {%- for assetConfig in assets -%}
                 {%- if assetConfig.type == 'stylesheet' -%}
@@ -30,17 +28,17 @@
                         <link rel="stylesheet" href="{{ assetConfig.url }}">
                     {% elseif assetConfig.body is defined -%}
                         <style>
-                            {{ assetConfig.body }}
+                            {{ assetConfig.body|raw }}
                         </style>
                     {% endif -%}
                 {%- elseif assetConfig.type == 'script' -%}
                     {%- if assetConfig.path is defined -%}
-                        <script defer src={{ asset(assetConfig.path) }}"></script>
+                        <script defer src="{{ asset(assetConfig.path) }}"></script>
                     {% elseif assetConfig.url is defined -%}
                         <script defer src="{{ assetConfig.url }}"></script>
                     {% elseif assetConfig.body is defined -%}
                         <script>
-                            {{ assetConfig.body }}
+                            {{ assetConfig.body|raw }}
                         </script>
                     {% endif -%}
                 {%- endif -%}

--- a/src/Zicht/Bundle/HtmldevBundle/Resources/views/macros/components.html.twig
+++ b/src/Zicht/Bundle/HtmldevBundle/Resources/views/macros/components.html.twig
@@ -31,7 +31,7 @@
     @param string slug The name of the component, which corresponds with the name of the file.
     @param object properties The properties of the component.
 #}
-{% macro styleguide_component(slug, properties) %}
+{% macro styleguide_component(slug, properties, outputs = ['example', 'twig']) %}
     {% import 'ZichtHtmldevBundle:macros:components.html.twig' as component %}
 
     {% set cx = {
@@ -40,7 +40,7 @@
             'c-component__view--dark': properties.styleguide_dark|default == true
         }),
         meta: classes({
-            'c-component__meta--full': properties.styleguide_component_width|default == 'full'
+            'c-component__meta--full': properties.styleguide_component_width|default == 'full' or 'example' not in outputs
         })
     } %}
 
@@ -51,9 +51,12 @@
             'styleguide_dark',
             'styleguide_component_width'
         ) %}
-        <div class="c-component__view  {{ cx.view }}">
-            {{ component.component(slug, component_properties) }}
-        </div>
+
+        {% if 'example' in outputs %}
+            <div class="c-component__view  {{ cx.view }}">
+                {{ component.component(slug, component_properties) }}
+            </div>
+        {% endif %}
 
         <div class="c-component__meta  {{ cx.meta }}">
             {% if properties.styleguide_title|default %}
@@ -64,8 +67,13 @@
                 <p class="c-component__description">{{ properties.styleguide_description }}</p>
             {% endif %}
 
-            {% set json = component_properties|ui_printable_arguments %}
-            <pre class="c-component__code">{{ '{{ ' }}ui.component('{{ slug }}', {{ json }}{{ ') }}' }}</pre>
+            {% if 'twig' in outputs %}
+                {% set json = component_properties|ui_printable_arguments %}
+                <pre class="c-component__code">{{ '{{ ' }}ui.component('{{ slug }}', {{ json }}{{ ') }}' }}</pre>
+            {% endif %}
+            {% if 'html' in outputs %}
+                <pre class="c-component__code">{{ component.component(slug, component_properties)|trim|escape }}</pre>
+            {% endif %}
         </div>
     </div>
 {% endmacro %}

--- a/src/Zicht/Bundle/HtmldevBundle/Resources/views/styleguide/_top.html.twig
+++ b/src/Zicht/Bundle/HtmldevBundle/Resources/views/styleguide/_top.html.twig
@@ -1,6 +1,6 @@
 
 <header class="c-page-header">
-    <h1 class="c-page-header__title"><a class="c-page-header__link" href="/htmldev">Styleguide</a></h1>
+    <h1 class="c-page-header__title"><a class="c-page-header__link" href="{{ path('zicht_htmldev_htmldev_index') }}">{{ styleguide.title }}</a></h1>
 
     {% set items = knp_menu_get('styleguide', [], { depth: 1 }) %}
     {% if items|default and items|length %}

--- a/src/Zicht/Bundle/HtmldevBundle/Resources/views/styleguide/component.html.twig
+++ b/src/Zicht/Bundle/HtmldevBundle/Resources/views/styleguide/component.html.twig
@@ -4,7 +4,8 @@
 
 
 {% block head_title -%}
-    Styleguide{% if name|default %} - {{ name|capitalize }}{% endif %}
+    {{- parent() -}}
+    {%- if name|default %} - {{ name|capitalize }}{% endif -%}
 {%- endblock %}
 
 
@@ -15,6 +16,6 @@
 
 {% block component_list %}
     {% for component in load_data(name) %}
-        {{ ui.styleguide_component(component.styleguide_type, component) }}
+        {{ ui.styleguide_component(component.styleguide_type, component, styleguide.outputs) }}
     {% endfor %}
 {% endblock %}

--- a/src/Zicht/Bundle/HtmldevBundle/Resources/views/styleguide/index.html.twig
+++ b/src/Zicht/Bundle/HtmldevBundle/Resources/views/styleguide/index.html.twig
@@ -1,9 +1,6 @@
 {% extends 'ZichtHtmldevBundle::_base.html.twig' %}
 
 
-{% block head_title 'Styleguide' %}
-
-
 {% block body %}
     {% block styleguide_top %}
         {% include 'ZichtHtmldevBundle:styleguide:_top.html.twig' %}


### PR DESCRIPTION
Added different options to the Htmldev bundle to be able to customize it more:

* Possibility to set the title (other than "Styleguide") within the bundle YAML config
* Possibility to make the Styleguide generate HTML snippets in the output (you can choose if you want to render an example, Twig output and/or HTML output) (alo configurable within the bundle YAML config)
* Possibility to add a homepage/introduction page (at `htmldev/pages/styleguide_intro.html.twig`) instead of going to the page of the first component in the list

TODO:

- [x] update README.md