### PR TITLE
Support different htmldev directory structures. Deprecate ui.component()

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Create living Styleguides with Symfony and Twig! ✨
       - [Rendering components](#rendering-components)
       - [Rendering SVG files](#rendering-svg-files)
    - [Customising](#customising)
+   - [Alternative structure](#alternative-structure)
 - [Development](#development)
    - [CSS](#css)
 ---
@@ -33,7 +34,7 @@ Create living Styleguides with Symfony and Twig! ✨
 
 ## Install
 
-1. Require via composer.   
+1. Require via composer.
 
    ```shell script
    composer require zicht/htmldev-bundle
@@ -43,7 +44,7 @@ Create living Styleguides with Symfony and Twig! ✨
 
 ### Setup
 
-1. Load the bundle into your AppKernel.   
+1. Load the bundle into your AppKernel.
 
    ```php
    new Zicht\Bundle\HtmldevBundle\ZichtHtmldevBundle()
@@ -51,7 +52,7 @@ Create living Styleguides with Symfony and Twig! ✨
 
 2. Configure routing.
 
-   Add the following Yaml to your app's route configuration.   
+   Add the following Yaml to your app's route configuration.
 
    ```yaml
    htmldev:
@@ -103,9 +104,9 @@ the following:
             styleguide:
                 title: 'Design System'
         ```
-      
+
     * To change the Styleguide's subtitle, or add a (SVG) logo, edit the config and add a `subtitle: '...'` element:
-    
+
         ```yaml
         zicht_htmldev:
           styleguide:
@@ -113,7 +114,7 @@ the following:
               subtitle: 'Zicht'
         ```
         Or you can use raw SVG-code, but don't forget to define a height that doesn't exceed 35px:
-        
+
         ```yaml
         zicht_htmldev:
           styleguide:
@@ -165,8 +166,8 @@ helper function:
         'u-margin--b2': image.url,
         'u-margin--b0  u-text--center': not image.url,
     })
-} %} 
-   
+} %}
+
 <article class="{{ cx.article }}">
     ...
 </article>
@@ -214,17 +215,17 @@ are only used to influence rendering of the component in the styleguide. The oth
 
 The available options for rendering in the styleguide are:
 
-- `styleguide_type`   
+- `styleguide_type`
   The name of the component to show. For example, `buttons/text` corresponds to the file `htmldev/components/buttons/text.html.twig`.
-- `styleguide_title`   
+- `styleguide_title`
   The title that will be rendered with the component.
-- `styleguide_description`   
+- `styleguide_description`
   An extra description of the component that will be rendered below the title.
-- `styleguide_dark` (`true`|`false`)   
+- `styleguide_dark` (`true`|`false`)
   A boolean indicating whether the styleguide should render the component on a dark background, for example for white buttons.
-- `styleguide_component_width`   
+- `styleguide_component_width`
   Override the default width of the component in the styleguide. Use a pixel/percentage/viewport unit to change the width of the component
-  next to the code example, e.g. `styleguide_component_width: 500px`. Or to render the code example below the component, use `styleguide_component_width: full`. 
+  next to the code example, e.g. `styleguide_component_width: 500px`. Or to render the code example below the component, use `styleguide_component_width: full`.
 
 
 #### Responsive image component
@@ -323,17 +324,17 @@ You can override this page (see [Pages](#pages)) to customize the HTML specially
 
 #### Rendering components
 
-The HtmldevBundle provides a `component` macro to render components from the styleguide anywhere in your application.
+*Rendering components through the `component` macro (`ui.component()`) is deprecated*
+
+To render components, simply use a Twig  include like below:
 
 This wil load `htmldev/components/cards/cover.html.twig` with the given properties:
- 
-```twig
-{% import '@ZichtHtmldev/macros/components.html.twig' as ui %}
 
-{{ ui.component('cards/cover', { 
+```twig
+{% include '@htmldev/components/cards/cover.html.twig' with {
     title: 'Hodor',
     url: '/some/page'
-}) }}
+} only %}
 ```
 
 #### Rendering SVG files
@@ -346,67 +347,84 @@ This will render the contents of `htmldev/images/icons/arrow--right.svg` in the 
 ```twig
 {% import '@ZichtHtmldev/macros/components.html.twig' as ui %}
 
-{{ ui.svg('arrow--right', { 
+{{ ui.svg('arrow--right', {
     width: 20,
     height: 20,
     directory: 'images/icons'
 }) }}
-``` 
+```
 
 The second argument is an options object. These keys are available:
 
-- `width`    
-  The width that should be set on the `<svg />` element. This will override an existing `width` attribute.  
-  The macro assumes `px`, so `width: 20` will be rendered as `<svg width="20px" />`. 
+- `width`
+  The width that should be set on the `<svg />` element. This will override an existing `width` attribute.
+  The macro assumes `px`, so `width: 20` will be rendered as `<svg width="20px" />`.
   Allowed values: [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width#svg).
-- `height`    
-  The height that should be set on the `<svg />` element. This will override an existing `height` attribute.  
-  The macro assumes `px`, so `height: 20` will be rendered as `<svg height="20px" />`. 
+- `height`
+  The height that should be set on the `<svg />` element. This will override an existing `height` attribute.
+  The macro assumes `px`, so `height: 20` will be rendered as `<svg height="20px" />`.
   Allowed values: [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/height#svg).
-- `viewbox_x` and `viewbox_y`    
+- `viewbox_x` and `viewbox_y`
   The `x` and `y` values of the `viewbox` property. This will override an existing `viewbox` attribute. These arguments
-  must both be passed, otherwise they will not be applied. 
+  must both be passed, otherwise they will not be applied.
   `viewbox_x: 20, viewbox_y: 30` will be rendered as `<svg viewbox="0 0 20 30" />`.
-- `css_classes`   
+- `css_classes`
   An array of CSS classes that will be applied to the `<svg />` element.
   `css_classes: ['u-white', 'u-block']` will be rendered as `<svg class="u-white  u-black" />`.
-- `attributes`   
+- `attributes`
   An array of extra attributes that will be applied to the `<svg />` element.
   This can be any attribute that's valid for the `<svg />` element.
   The default value for this parameter is `{ 'aria-hidden: 'true', 'role: 'img' }`.
-- `title`   
+- `title`
   This will add a `<title />` element inside the `<svg />` for accessibility improvements.
   Reference: [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title)
-- `directory`   
-  The directory where the SVG file is located. This must be a directory inside the directory that's marked as 
+- `directory`
+  The directory where the SVG file is located. This must be a directory inside the directory that's marked as
   the root of the HtmldevBundle (default `htmldev`).
-   
+
 ### Customising
 
 There are several Symfony parameters available to override, to add a different implementation.
 
-- `htmldev.directory` (default: `%kernel.root_dir%/../htmldev`)   
-  Change the styleguide directory. 
-- `htmldev.controller`   
+- `htmldev.directory` (default: `%kernel.root_dir%/../htmldev`)
+  Change the styleguide directory.
+- `htmldev.controller`
   The controller that handles the requests for pages inside the styleguide.
-- `htmldev.color_service`   
-  The service that reads colors from a Sass variable in ZSS. To change the way this works, implement the `ColorServiceInterface` 
+- `htmldev.color_service`
+  The service that reads colors from a Sass variable in ZSS. To change the way this works, implement the `ColorServiceInterface`
   class and change this parameter to your own class.
-- `htmldev.svg_service`   
+- `htmldev.svg_service`
   The service that returns the contents of SVG files. To change the way this works, implement the `SvgServiceInterface` and
   change this parameter to your own class.
+
+### Alternative structure
+
+It is possible to move everything out of the HtmldevBundle's default htmldev/ directory by changing a few configurations.
+For instance, to adhere to a more industry standard structure in a Symfony 4+ project:
+
+Add to `config/packages/zicht_htmldev.yaml`:
+```yaml
+zicht_htmldev:
+    paths:
+        data: '%kernel.project_dir%/config/packages/_zicht_htmldev'
+        images_icons: '%kernel.project_dir%/assets/images/icons/'
+        sass_variables: '%kernel.project_dir%/assets/sass/variables/'
+        svg_service_base_dir: '%kernel.project_dir%/assets/'
+```
+
+And move stuff around accordingly.
 
 ## Development
 
 ### CSS
 
-The bundle contains a CSS file to provide default styling for the styleguide. 
+The bundle contains a CSS file to provide default styling for the styleguide.
 
 - The source of this CSS file is `styleguide.scss`, located in the [Resourcs/sass](src/Zicht/Bundle/HtmldevBundle/Resources/sass) folder.
 - The Sass files are compiled with webpack and node-sass.
 - The Sass files are linted with [stylelint-config-zicht](https://github.com/zicht/stylelint-config-zicht).
 
-Run `npm run build` to add your features or bug fixes to the compiled CSS file, and don't forget to commit the 
+Run `npm run build` to add your features or bug fixes to the compiled CSS file, and don't forget to commit the
 resulting files in `~/Resources/public/css`.
 
 ## Maintainer

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,7 +24,17 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('htmldev');
 
         $rootNode
+            ->fixXmlConfig('path')
             ->children()
+                ->arrayNode('paths')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('data')->defaultValue('%htmldev.directory%/data/')->end()
+                        ->scalarNode('images_icons')->defaultValue('%htmldev.directory%/images/icons/')->end()
+                        ->scalarNode('sass_variables')->defaultValue('%htmldev.directory%/sass/variables/')->end()
+                        ->scalarNode('svg_service_base_dir')->defaultValue('%htmldev.directory%')->end()
+                    ->end()
+                ->end()
                 ->arrayNode('svg_cache')
                     ->addDefaultsIfNotSet()
                         ->info('This should be a service prefixed with @ fro0r an service or one of "file", "array", or "apcu" values.')

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -25,24 +25,25 @@
             <argument type="service" id="htmldev.text_data_loader" />
         </service>
 
-        <service id="htmldev.abstract_data_loader" abstract="true">
-            <argument type="string">%htmldev.directory%</argument>
+        <service id="Zicht\Bundle\HtmldevBundle\Service\AbstractDataLoader" abstract="true">
+            <argument type="collection"/> <!-- set by config -->
         </service>
+        <service id="htmldev.abstract_data_loader" alias="Zicht\Bundle\HtmldevBundle\Service\AbstractDataLoader" />
 
         <service id="htmldev.yaml_data_loader" class="Zicht\Bundle\HtmldevBundle\Service\YamlDataLoader" parent="htmldev.abstract_data_loader" />
 
         <service id="htmldev.text_data_loader" class="Zicht\Bundle\HtmldevBundle\Service\TextDataLoader" parent="htmldev.abstract_data_loader" />
 
-        <service id="htmldev.svg_service" class="%htmldev.svg_service%">
-            <argument type="string">%htmldev.directory%</argument>
-            <argument/> <!-- set by config -->
+        <service id="Zicht\Bundle\HtmldevBundle\Service\SvgService" class="%htmldev.svg_service%">
+            <argument type="string"/> <!-- Base dir, set by config -->
+            <argument/> <!-- Cache, set by config -->
             <argument type="service" id="logger"/>
             <tag name="monolog.logger" channel="svg_service"/>
         </service>
+        <service id="htmldev.svg_service" alias="Zicht\Bundle\HtmldevBundle\Service\SvgService"/>
 
         <!-- Twig extensions -->
         <service id="htmldev.twig.data_extension" class="Zicht\Bundle\HtmldevBundle\Twig\DataExtension">
-            <argument type="string">%htmldev.directory%</argument>
             <argument type="service" id="htmldev.yaml_data_loader" />
             <tag name="twig.extension"/>
         </service>
@@ -52,11 +53,12 @@
             <tag name="twig.extension"/>
         </service>
 
-        <service id="htmldev.twig.image_extension" class="Zicht\Bundle\HtmldevBundle\Twig\ImageExtension">
-            <argument type="string">%htmldev.directory%</argument>
+        <service id="Zicht\Bundle\HtmldevBundle\Twig\ImageExtension">
+            <argument type="string"/> <!-- Image Directory, set by config -->
             <argument type="service" id="htmldev.svg_service" />
             <tag name="twig.extension"/>
         </service>
+        <service id="htmldev.twig.image_extension" alias="Zicht\Bundle\HtmldevBundle\Twig\ImageExtension"/>
 
         <service id="htmldev.twig.util_extension" class="Zicht\Bundle\HtmldevBundle\Twig\UtilExtension">
             <tag name="twig.extension"/>

--- a/src/Resources/views/macros/components.html.twig
+++ b/src/Resources/views/macros/components.html.twig
@@ -15,6 +15,8 @@
 
     @param string slug The name of the component, which corresponds with the name of the file.
     @param object properties The properties of the component.
+
+    @deprecated
 #}
 {% macro component(slug, properties) %}
     {% strict false %}
@@ -25,14 +27,18 @@
 
 
 {#
-    This method does exactly the same as the `component()` macro, except it's intended
-    for rendering inside the style guide, with code examples et cetera.
+    For rendering inside the style guide, with code examples et cetera.
 
-    @param string slug The name of the component, which corresponds with the name of the file.
+    @param string template The path of the component template.
     @param object properties The properties of the component.
 #}
-{% macro styleguide_component(slug, properties, outputs = ['example', 'twig']) %}
-    {% import '@ZichtHtmldev/macros/components.html.twig' as component %}
+{% macro styleguide_component(template, properties, outputs = ['example', 'twig']) %}
+    {% if 'components/' not in template %}
+        {% set template = '@htmldev/components/' ~ template %}
+    {% endif %}
+    {% if '.html.twig' not in template %}
+        {% set template = template ~ '.html.twig' %}
+    {% endif %}
 
     {% set cx = {
         container: classes({
@@ -57,7 +63,9 @@
 
         {% if 'example' in outputs %}
             <div class="c-component__view  {{ cx.view }}">
-                {{ component.component(slug, component_properties) }}
+                {% strict false %}
+                    {% include template with component_properties only %}
+                {% endstrict %}
             </div>
         {% endif %}
 
@@ -72,10 +80,19 @@
 
             {% if 'twig' in outputs %}
                 {% set json = component_properties|ui_printable_arguments %}
-                <pre class="c-component__code">{{ '{{ ' }}ui.component('{{ slug }}', {{ json }}{{ ') }}' }}</pre>
+                <pre class="c-component__code">{{ '{% ' }}include '{{ template }}' with {{ json }} only{{ ' %}' }}</pre>
             {% endif %}
+
             {% if 'html' in outputs %}
-                <pre class="c-component__code">{{ component.component(slug, component_properties)|trim|escape }}</pre>
+                <pre class="c-component__code">
+                    {%- apply escape -%}
+                        {%- apply trim -%}
+                            {%- strict false -%}
+                                {%- include template with component_properties only -%}
+                            {%- endstrict -%}
+                        {%- endapply -%}
+                    {%- endapply -%}
+                </pre>
             {% endif %}
         </div>
     </div>

--- a/src/Service/AbstractDataLoader.php
+++ b/src/Service/AbstractDataLoader.php
@@ -2,6 +2,7 @@
 /**
  * @copyright Zicht Online <http://zicht.nl>
  */
+
 namespace Zicht\Bundle\HtmldevBundle\Service;
 
 use Symfony\Component\Finder\Finder;
@@ -12,17 +13,15 @@ use Symfony\Component\Yaml\Yaml;
  */
 abstract class AbstractDataLoader implements DataLoaderInterface
 {
-    /** @var string */
-    private $htmldevDirectory;
+    /** @var string[] */
+    private $paths;
 
     /**
-     * Initializes a new instance of the AbstractDataLoader class.
-     *
-     * @param string $htmldevDirectory
+     * @param array $paths
      */
-    public function __construct($htmldevDirectory)
+    public function __construct($paths)
     {
-        $this->htmldevDirectory = $htmldevDirectory;
+        $this->paths = $paths;
     }
 
     /**
@@ -37,7 +36,28 @@ abstract class AbstractDataLoader implements DataLoaderInterface
         $finder = new Finder();
 
         return $finder
-            ->in(sprintf('%s/%s', $this->htmldevDirectory, $directory))
+            ->in($this->findPath($directory))
             ->name($namePattern);
+    }
+
+    /**
+     * @param string $directory
+     * @return string
+     */
+    protected function findPath($directory)
+    {
+        if (strpos($directory, '/') === false) {
+            return $this->paths[$directory] ?? $directory;
+        }
+
+        $dirParts = explode('/', $directory);
+        do {
+            $tryPathKey = implode('_', $dirParts);
+            if (isset($this->paths[$tryPathKey])) {
+                return $this->paths[$tryPathKey];
+            }
+        } while (array_pop($dirParts));
+
+        return $directory;
     }
 }

--- a/src/Twig/DataExtension.php
+++ b/src/Twig/DataExtension.php
@@ -13,21 +13,16 @@ use Zicht\Bundle\HtmldevBundle\Service\DataLoaderInterface;
  */
 class DataExtension extends Twig_Extension
 {
-    /** @var string */
-    private $htmldevDirectory;
-
     /** @var DataLoaderInterface */
     private $yamlLoader;
 
     /**
      * Initializes a new instance of the DataExtension class.
      *
-     * @param string $htmldevDirectory
      * @param DataLoaderInterface $yamlLoader
      */
-    public function __construct($htmldevDirectory, DataLoaderInterface $yamlLoader)
+    public function __construct(DataLoaderInterface $yamlLoader)
     {
-        $this->htmldevDirectory = $htmldevDirectory;
         $this->yamlLoader = $yamlLoader;
     }
 

--- a/src/Twig/ImageExtension.php
+++ b/src/Twig/ImageExtension.php
@@ -16,7 +16,7 @@ use Zicht\Bundle\HtmldevBundle\Service\SvgServiceInterface;
 class ImageExtension extends Twig_Extension
 {
     /** @var string */
-    private $htmldevDirectory;
+    private $imageDirectory;
 
     /** @var SvgServiceInterface */
     private $svgService;
@@ -24,12 +24,12 @@ class ImageExtension extends Twig_Extension
     /**
      * Initializes a new instance of the ImageExtension class.
      *
-     * @param string $htmldevDirectory
+     * @param string $imageDirectory
      * @param SvgServiceInterface $svgService
      */
-    public function __construct($htmldevDirectory, SvgServiceInterface $svgService)
+    public function __construct($imageDirectory, SvgServiceInterface $svgService)
     {
-        $this->htmldevDirectory = $htmldevDirectory;
+        $this->imageDirectory = $imageDirectory;
         $this->svgService = $svgService;
     }
 
@@ -52,15 +52,15 @@ class ImageExtension extends Twig_Extension
      */
     public function getIcons($type = '')
     {
-        $imageDirectory = sprintf('%s/images/icons/%s', $this->htmldevDirectory, $type);
+        $imageDirectory = sprintf('%s/%s', rtrim($this->imageDirectory, '/'), $type);
         if (!is_dir($imageDirectory)) {
             return [];
         }
 
         $files = array_diff(scandir($imageDirectory), ['..', '.']);
         return array_map(
-            function ($item) {
-            return basename($item, '.svg');
+            static function ($item) {
+                return basename($item, '.svg');
             },
             $files
         );


### PR DESCRIPTION
Forward compatibility