### PR TITLE
Fixed deprecated Twig template notation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ The HtmldevBundle provides a `component` macro to render components from the sty
 This wil load `htmldev/components/cards/cover.html.twig` with the given properties:
  
 ```twig
-{% import 'ZichtHtmldevBundle:macros:components.html.twig' as ui %}
+{% import '@ZichtHtmldev/macros/components.html.twig' as ui %}
 
 {{ ui.component('cards/cover', { 
     title: 'Hodor',
@@ -344,7 +344,7 @@ easy coloring of the SVG with `currentColor` and CSS.
 This will render the contents of `htmldev/images/icons/arrow--right.svg` in the HTML:
 
 ```twig
-{% import 'ZichtHtmldevBundle:macros:components.html.twig' as ui %}
+{% import '@ZichtHtmldev/macros/components.html.twig' as ui %}
 
 {{ ui.svg('arrow--right', { 
     width: 20,

--- a/src/Controller/HtmldevController.php
+++ b/src/Controller/HtmldevController.php
@@ -76,9 +76,9 @@ class HtmldevController extends AbstractController
     public function showAction($section)
     {
         $templates = [
-            sprintf('@htmldev/pages/%s.html.twig', $section),                 // Override: Custom section specific template
-            sprintf('ZichtHtmldevBundle::styleguide/%s.html.twig', $section), // Section specific template
-            'ZichtHtmldevBundle:styleguide:component.html.twig',              // No custom template, use general component template
+            sprintf('@htmldev/pages/%s.html.twig', $section),           // Override: Custom section specific template
+            sprintf('@ZichtHtmldev/styleguide/%s.html.twig', $section), // Section specific template
+            '@ZichtHtmldev/styleguide/component.html.twig',             // No custom template, use general component template
             null, // Final value when nothing is found
         ];
         do {

--- a/src/Resources/views/components/images/image.html.twig
+++ b/src/Resources/views/components/images/image.html.twig
@@ -5,7 +5,7 @@
     1. npm install lazysizes --save
     2. import 'lazysizes'; // in main.ts
     3. @import "../../vendor/zicht/htmldev-bundle/src/Resources/sass/components/lazyload.scss"; // in main.scss
-    4. {% import 'ZichtHtmldevBundle:components/images:image.html.twig' as img %}
+    4. {% import '@ZichtHtmldev/components/images/image.html.twig' as img %}
     5. {{ img.component({
         image_source: 'sourcestring',
         image_alt: 'altstring',
@@ -83,7 +83,7 @@
 {#
     In your project import the component just like you normally would import components from the htmldev folder.
     Instead this time you import it from the htmldev-bundle on top of the file:
-    {% import 'ZichtHtmldevBundle:components/images:image.html.twig' as img %}
+    {% import '@ZichtHtmldev/components/images/image.html.twig' as img %}
 
     Where you want to include an image:
     {{ img.component({
@@ -127,11 +127,11 @@
     {% if properties.image_source|default or properties.breakpoints|default|length > 0 %}
         {% if properties.lazyload %}
             {# Lazyload the images #}
-            {% include 'ZichtHtmldevBundle:components/images:image--lazyload.html.twig' with properties only %}
+            {% include '@ZichtHtmldev/components/images/image--lazyload.html.twig' with properties only %}
 
         {% else %}
             {# If lazyload is false, fallback to browser default mechanics of responsive images #}
-            {% include 'ZichtHtmldevBundle:components/images:image--responsive.html.twig' with properties only %}
+            {% include '@ZichtHtmldev/components/images/image--responsive.html.twig' with properties only %}
 
         {% endif %}
     {% endif %}

--- a/src/Resources/views/macros/components.html.twig
+++ b/src/Resources/views/macros/components.html.twig
@@ -32,7 +32,7 @@
     @param object properties The properties of the component.
 #}
 {% macro styleguide_component(slug, properties, outputs = ['example', 'twig']) %}
-    {% import 'ZichtHtmldevBundle:macros:components.html.twig' as component %}
+    {% import '@ZichtHtmldev/macros/components.html.twig' as component %}
 
     {% set cx = {
         container: classes({

--- a/src/Resources/views/macros/styleguide.html.twig
+++ b/src/Resources/views/macros/styleguide.html.twig
@@ -32,7 +32,7 @@
 
 
 {% macro icons(icon_list) %}
-    {% import 'ZichtHtmldevBundle:macros:components.html.twig' as ui %}
+    {% import '@ZichtHtmldev/macros/components.html.twig' as ui %}
 
     {% if icon_list|default and icon_list|length %}
         <div class="c-icon-list">

--- a/src/Resources/views/styleguide/component.html.twig
+++ b/src/Resources/views/styleguide/component.html.twig
@@ -1,6 +1,6 @@
 {# Try htmldev/_base.html.twig first. Kept this in for backward compatibility (BC) #}
-{% extends ['@htmldev/_base.html.twig', 'ZichtHtmldevBundle:styleguide:index.html.twig'] %}
-{% import 'ZichtHtmldevBundle::macros/components.html.twig' as ui %}
+{% extends ['@htmldev/_base.html.twig', '@ZichtHtmldev/styleguide/index.html.twig'] %}
+{% import '@ZichtHtmldev/macros/components.html.twig' as ui %}
 
 
 {% block head_title -%}

--- a/src/Resources/views/styleguide/design-elements/colors.html.twig
+++ b/src/Resources/views/styleguide/design-elements/colors.html.twig
@@ -1,5 +1,5 @@
-{% extends ['@htmldev/pages/component.html.twig', 'ZichtHtmldevBundle:styleguide:component.html.twig'] %}
-{% import 'ZichtHtmldevBundle:macros:styleguide.html.twig' as styleguide %}
+{% extends ['@htmldev/pages/component.html.twig', '@ZichtHtmldev/styleguide/component.html.twig'] %}
+{% import '@ZichtHtmldev/macros/styleguide.html.twig' as styleguide %}
 
 
 {% block component_list %}

--- a/src/Resources/views/styleguide/design-elements/icons.html.twig
+++ b/src/Resources/views/styleguide/design-elements/icons.html.twig
@@ -1,5 +1,5 @@
-{% extends ['@htmldev/pages/component.html.twig', 'ZichtHtmldevBundle:styleguide:component.html.twig'] %}
-{% import 'ZichtHtmldevBundle:macros:styleguide.html.twig' as styleguide %}
+{% extends ['@htmldev/pages/component.html.twig', '@ZichtHtmldev/styleguide/component.html.twig'] %}
+{% import '@ZichtHtmldev/macros/styleguide.html.twig' as styleguide %}
 
 
 {% block component_list %}

--- a/src/Resources/views/styleguide/design-elements/typography.html.twig
+++ b/src/Resources/views/styleguide/design-elements/typography.html.twig
@@ -1,5 +1,5 @@
-{% extends ['@htmldev/pages/component.html.twig', 'ZichtHtmldevBundle:styleguide:component.html.twig'] %}
-{% import 'ZichtHtmldevBundle:macros:styleguide.html.twig' as styleguide %}
+{% extends ['@htmldev/pages/component.html.twig', '@ZichtHtmldev/styleguide/component.html.twig'] %}
+{% import '@ZichtHtmldev/macros/styleguide.html.twig' as styleguide %}
 
 {% block component_intro %}
     <h1 class="c-copy--h1">{{ name|capitalize }}</h1>
@@ -14,7 +14,7 @@
         </p>
     </section>
     <section class="c-component--typography  s-cms-content" style="max-width: 980px;">
-        
+
         <h2>Jived fox nymph grabs quick waltz?</h2>
         <p>
             That’s not the only ballroom dance. I take lessons too. There’s Salsa, Tango, Waltz,

--- a/src/Resources/views/styleguide/index.html.twig
+++ b/src/Resources/views/styleguide/index.html.twig
@@ -1,14 +1,14 @@
-{% extends 'ZichtHtmldevBundle::_base.html.twig' %}
+{% extends '@ZichtHtmldev/_base.html.twig' %}
 
 
 {% block body %}
     {% block styleguide_top %}
-        {% include 'ZichtHtmldevBundle:styleguide:_top.html.twig' %}
+        {% include '@ZichtHtmldev/styleguide/_top.html.twig' %}
     {% endblock %}
 
     <main class="c-content">
         {% block styleguide_aside %}
-            {% include 'ZichtHtmldevBundle:styleguide:_side-bar.html.twig' %}
+            {% include '@ZichtHtmldev/styleguide/_side-bar.html.twig' %}
         {% endblock %}
 
         <div class="c-content__main">


### PR DESCRIPTION
Changed all `FooBundle:dir:template.html.twig` into `@Foo/dir/template.html.twig`