### PR TITLE
Remove version from document title in _base.html.twig

### DIFF
--- a/src/Resources/views/_base.html.twig
+++ b/src/Resources/views/_base.html.twig
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <title>{%- if app.environment not in ['prod','production'] and version is not empty %}{{ version ~ ' - ' }}{% endif %}{% block head_title styleguide.title %}</title>
+        <title>{% block head_title styleguide.title %}</title>
 
         {%~ block head_copyright %}
             <!--


### PR DESCRIPTION
It has happened several times that the version number ended up on the production environment for some reason, so it's probably better to just remove it from the title. If you want to know the version, you should check the page source and look for the informational comment containing the copyright, contact and... **version** information.