### PR TITLE
Add lang attribute on html tag

### DIFF
--- a/src/Resources/views/_base.html.twig
+++ b/src/Resources/views/_base.html.twig
@@ -1,6 +1,10 @@
 {% set version = asset_version('/') -%}
 <!doctype html>
-<html class="s-no-javascript  not-loaded  {% block html_class '' %}" {% block html_attributes '' %}>
+<html class="s-no-javascript  not-loaded  {% block html_class '' %}" {% block html_attributes -%}
+    {%- if app is defined and app.request and app.request.locale -%}
+        lang="{{ app.request.locale|lower }}"
+    {%- endif -%}
+{%- endblock %}>
     <head>
         <meta charset="UTF-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
We already do this in many projects and if we add it here, than we have it in all our projects and we have a central place where it can be maintained and improved. Having this lang attribute is a best practice and also better for SEO.

In projects we have:
```twig
{% block html_attributes %}lang="{{ app.request.locale|lower }}"{% endblock %}
{% block html_attributes %}lang="{{ app.request.locale }}"{% endblock %}
{% block html_attributes %}lang="{{ app.request.locale|lower }}-{{ app.request.locale|upper }}"{% endblock %}
{% block html_attributes %}lang="nl" xml:lang="nl"{% endblock %}
{% block html_attributes %}lang="{{ app.request.locale }}" xml:lang="{{ app.request.locale }}"{% endblock %}
```

The `xml:lang` attribute is for XML documents, so we don't need it. When specifying both `lang` and `xml:lang`, then `lang` is being used, so in any way, it is not necessary to use `xml:lang`.

The value of the `lang` attribute must comply to the BCP47 specification, which in short says that there are 3 parts, separated by dashes: `language-script-region`. Only the first is required (`en` or `nl`). Above you see `{{ app.request.locale|lower }}-{{ app.request.locale|upper }}` is being used somewhere (resulting in `en-EN` or `nl-NL`). This might cause issues, because `app.request.locale` is the language, but `app.request.locale` might not be equal to the script in many cases: `en-GB`, `en-US`, `fr-CA`. Since only the language is required, I propose to only use that.

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#language_tag_syntax