### PR TITLE
Do not add XML declaration to inline SVGs

### DIFF
--- a/src/Service/SvgService.php
+++ b/src/Service/SvgService.php
@@ -63,7 +63,7 @@ class SvgService implements SvgServiceInterface
              * Add CSS classes for extra theming or positioning.
              */
             if (is_array($cssClasses)) {
-                $this->setSvgAttribute($svg, 'class',  implode('  ', $cssClasses));
+                $this->setSvgAttribute($svg, 'class', trim(implode('  ', $cssClasses)));
             }
             if (!empty($title)) {
                 $this->logger->debug(sprintf('adding title to svg: "%s"', $title));
@@ -78,7 +78,7 @@ class SvgService implements SvgServiceInterface
                     $svg->setAttribute($attr, $value);
                 }
             }
-            $out = $d->saveXML();
+            $out = $d->saveXML($d->documentElement);
             $this->cache->set($key, $out);
         } else {
             $this->logger->info('svg ' . $name . ' loaded from cache');


### PR DESCRIPTION
The XML declaration (`<?xml version="1.0"?>`) was added by `DOMDocument::saveXML()`. SVGs should contain this XML declaration as the first line of the file, but inline SVGs should not as this results in `<?xml version="1.0"?>` lines everywhere within an HTML document.

Saving the node of the XML SVG document instead of the whole document, results in the same output but without the XML declaration line.